### PR TITLE
Update header styling and replace Building icon with logo

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,20 +118,18 @@ export default function Dashboard() {
   return (
     <div className="min-h-screen bg-white">
       {/* Navigation Header */}
-      <header className="sticky top-0 z-50 border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+      <header className="sticky top-0 z-50 border-b bg-[#08312a] backdrop-blur">
         <div className="container mx-auto px-4 lg:px-8">
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center space-x-8">
               <div className="flex items-center space-x-3">
-                <div className="flex h-8 w-8 items-center justify-center rounded bg-[#08312a] p-1">
-                  <img
-                    src="/assets/primary-logo-accent.svg"
-                    alt="BI Dashboard Logo"
-                    className="h-full w-full"
-                  />
-                </div>
+                <img
+                  src="/assets/primary-logo-accent.svg"
+                  alt="BI Dashboard Logo"
+                  className="h-8 w-8"
+                />
                 <h1
-                  className="text-xl font-medium text-[#002c5f]"
+                  className="text-xl font-medium text-white"
                   style={{ fontFamily: "var(--font-headline)" }}
                 >
                   BI Dashboard

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,8 +132,7 @@ export default function Dashboard() {
                   className="text-xl font-medium text-white"
                   style={{ fontFamily: "var(--font-headline)" }}
                 >
-                  BI{" "}
-                  <span style={{ color: "rgb(0, 228, 124)" }}>Dashboard</span>
+                  Dashboard
                 </h1>
               </div>
               <nav className="hidden md:flex items-center space-x-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -124,8 +124,12 @@ export default function Dashboard() {
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center space-x-8">
               <div className="flex items-center space-x-3">
-                <div className="flex h-8 w-8 items-center justify-center rounded bg-[#002c5f]">
-                  <Building className="h-5 w-5 text-white" />
+                <div className="flex h-8 w-8 items-center justify-center rounded bg-[#08312a] p-1">
+                  <img
+                    src="/assets/primary-logo-accent.svg"
+                    alt="BI Dashboard Logo"
+                    className="h-full w-full"
+                  />
                 </div>
                 <h1
                   className="text-xl font-medium text-[#002c5f]"
@@ -137,19 +141,19 @@ export default function Dashboard() {
               <nav className="hidden md:flex items-center space-x-6">
                 <a
                   href="#"
-                  className="text-sm font-medium text-gray-700 hover:text-[#002c5f] transition-colors"
+                  className="text-sm font-medium text-white hover:text-[#00e47c] active:text-[#00e47c] transition-colors"
                 >
                   Billing
                 </a>
                 <a
                   href="#"
-                  className="text-sm font-medium text-gray-700 hover:text-[#002c5f] transition-colors"
+                  className="text-sm font-medium text-white hover:text-[#00e47c] active:text-[#00e47c] transition-colors"
                 >
                   Projects
                 </a>
                 <a
                   href="#"
-                  className="text-sm font-medium text-gray-700 hover:text-[#002c5f] transition-colors"
+                  className="text-sm font-medium text-white hover:text-[#00e47c] active:text-[#00e47c] transition-colors"
                 >
                   Cluster Info
                 </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,7 +126,7 @@ export default function Dashboard() {
                 <img
                   src="/assets/primary-logo-accent.svg"
                   alt="BI Dashboard Logo"
-                  className="h-8 w-8"
+                  className="h-auto w-[140px]"
                 />
                 <h1
                   className="text-xl font-medium text-white"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,7 +118,7 @@ export default function Dashboard() {
   return (
     <div className="min-h-screen bg-white">
       {/* Navigation Header */}
-      <header className="sticky top-0 z-50 border-b bg-[#08312a] backdrop-blur">
+      <header className="sticky top-0 z-50 border-b bg-[#08312a] backdrop-blur h-20 flex flex-col justify-center items-center">
         <div className="container mx-auto px-4 lg:px-8">
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center space-x-8">
@@ -132,7 +132,8 @@ export default function Dashboard() {
                   className="text-xl font-medium text-white"
                   style={{ fontFamily: "var(--font-headline)" }}
                 >
-                  BI Dashboard
+                  BI{" "}
+                  <span style={{ color: "rgb(0, 228, 124)" }}>Dashboard</span>
                 </h1>
               </div>
               <nav className="hidden md:flex items-center space-x-6">
@@ -203,7 +204,10 @@ export default function Dashboard() {
               <CardContent>
                 <div className="flex items-center space-x-2">
                   <TrendingUp className="h-5 w-5 text-green-600" />
-                  <span className="text-3xl font-bold text-green-600">
+                  <span
+                    className="text-3xl font-bold"
+                    style={{ color: "rgba(0, 228, 124, 1)" }}
+                  >
                     +6.4%
                   </span>
                 </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import {
   Filter,
   TrendingUp,
   TrendingDown,
-  Building,
   User,
   ChevronDown,
   Server,


### PR DESCRIPTION
Updates the dashboard header with new styling and branding:

- Replace Building icon with primary logo SVG image
- Change header background from white to dark green (#08312a)
- Update header height to 20 with flex centering
- Change text colors from dark blue/gray to white
- Add green accent color (#00e47c) for hover/active states on navigation links
- Update "BI Dashboard" title to just "Dashboard"
- Change growth percentage color to custom green (rgba(0, 228, 124, 1))
- Remove unused Building import from lucide-react

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fa5eecb525064c92bc2370e372c05141/vibe-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fa5eecb525064c92bc2370e372c05141</projectId>-->
<!--<branchName>vibe-haven</branchName>-->