### PR TITLE
Update font size from text-3xl to 40px inline style

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -185,7 +185,10 @@ export default function Dashboard() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold text-gray-900">
+                <div
+                  className="font-bold text-gray-900"
+                  style={{ fontSize: "40px" }}
+                >
                   CHF 12'390
                 </div>
                 <p className="text-xs text-gray-500 mt-1">


### PR DESCRIPTION
Changes the font size styling for the CHF amount display:

- Removes `text-3xl` Tailwind class
- Adds inline `fontSize: "40px"` style
- Maintains `font-bold text-gray-900` classes

The div element is reformatted across multiple lines to accommodate the new inline style attribute.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fa5eecb525064c92bc2370e372c05141/spark-landing)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fa5eecb525064c92bc2370e372c05141</projectId>-->
<!--<branchName>spark-landing</branchName>-->